### PR TITLE
Non tree array

### DIFF
--- a/TreeNode.js
+++ b/TreeNode.js
@@ -114,6 +114,10 @@ export default class Node {
             return undefined;
         }
 
+        if (!array.every(node => typeof node === "object")) {
+            return undefined;
+        }
+
         var clone;
         if (array.length === 1) {
             if (isNode(array[0])) {
@@ -123,19 +127,23 @@ export default class Node {
             return clone;
         }
 
-        if (array[0].use !== "start") {
-            // not a real tree
-            return undefined;
+        let rootExtra, startIndex = 0;
+        if (array[0].use === "start") {
+            rootExtra = array[0];
+            startIndex = 1;
+        } else {
+            rootExtra = {type: "root"};
+            startIndex = 0;
         }
-
-        let root = new Node(array[0]);
+        // not a tree? Make a wrapper node!
+        let root = new Node(rootExtra);
         let stack = [];
         let current = root;
 
         root.use = undefined;
         stack.push(root);
 
-        for (var i = 1; i < array.length; i++) {
+        for (var i = startIndex; i < array.length; i++) {
             if (isNode(array[i])) {
                 if (array[i].use === "start") {
                     clone = new Node(array[i]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tree-node",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": "./TreeNode-es5.js",
     "main-es6": "./TreeNode.js",
     "description": "A package to build, construct, and deconstruct an arbitrary tree of nodes.",

--- a/test/testtreenode.js
+++ b/test/testtreenode.js
@@ -758,7 +758,7 @@ module.exports.testTreeNode = {
 
         test.equal(array.length, 1);
 
-        var node = Node.fromArray();
+        var node = Node.fromArray(array);
 
         test.ok(!node);
 
@@ -782,7 +782,7 @@ module.exports.testTreeNode = {
 
         test.equal(array.length, 3);
 
-        var node = Node.fromArray();
+        var node = Node.fromArray(array);
 
         test.ok(!node);
 
@@ -818,5 +818,61 @@ module.exports.testTreeNode = {
         test.ok(!node);
 
         test.done();
-    }
+    },
+
+    testNodeFromArrayNonTree: function(test) {
+        test.expect(14);
+
+        let array = [];
+        array.push(new Node({
+            type: "text",
+            value: "foobar"
+        }));
+        array.push(new Node({
+            type: "component",
+            use: "start",
+            extra: {
+                name: "X"
+            }
+        }));
+        array.push(new Node({
+            type: "component",
+            extra: {name: "A"},
+            use: "startend"
+        }));
+        array.push(new Node({
+            type: "component",
+            use: "end"
+        }));
+        array.push(new Node({
+            type: "text",
+            value: "asdf asdf"
+        }));
+
+        let node = Node.fromArray(array);
+
+        // should get an automatic root node and the
+        // nodes above should be its children
+        test.ok(node);
+
+        test.equal(node.type, "root");
+        test.ok(node.children);
+        test.equal(node.children.length, 3);
+
+        test.ok(node.children[0]);
+        test.equal(node.children[0].type, "text");
+        test.equal(node.children[0].value, "foobar");
+
+        test.ok(node.children[1]);
+        test.equal(node.children[1].type, "component");
+        test.deepEqual(node.children[1].extra, {name: "X"});
+        test.equal(node.children[1].children.length, 1);
+
+        test.ok(node.children[2]);
+        test.equal(node.children[2].type, "text");
+        test.equal(node.children[2].value, "asdf asdf");
+
+        test.done();
+    },
+
 };


### PR DESCRIPTION
When converting an array of tree nodes into a tree in the Node.fromArray() method, we should not require that the first node in the array is a root of all the other nodes in the tree. Some arrays are just a sequence of nodes and do not form a whole tree.

To deal with this, we now create a new, fake root node and add these arbitrary children to this root node and return it.