### PR TITLE
Fixed a bug where a mal-formed tree could cause an exception

### DIFF
--- a/TreeNode.js
+++ b/TreeNode.js
@@ -152,7 +152,7 @@ export default class Node {
                     current.add(clone);
                     current = clone;
                 } else if (array[i].use === "end") {
-                    if (stack.length) {
+                    if (stack.length > 1) {
                         stack.pop();
                         current = stack[stack.length-1];
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tree-node",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "main": "./TreeNode-es5.js",
     "main-es6": "./TreeNode.js",
     "description": "A package to build, construct, and deconstruct an arbitrary tree of nodes.",

--- a/test/testtreenode.js
+++ b/test/testtreenode.js
@@ -875,4 +875,56 @@ module.exports.testTreeNode = {
         test.done();
     },
 
+    testNodeFromArrayNotWellFormed: function(test) {
+        test.expect(12);
+
+        let array = [];
+        array.push(new Node({
+            type: "text",
+            value: "asdf",
+        }));
+        array.push(new Node({
+            type: "parent",
+            use: "start"
+        }));
+        array.push(new Node({
+            type: "text",
+            value: "bar",
+        }));
+        array.push(new Node({
+            type: "parent",
+            use: "end"
+        }));
+        // this one is an end without a start:
+        array.push(new Node({
+            type: "parent",
+            use: "end"
+        }));
+        // this one should not cause an exception
+        array.push(new Node({
+            type: "text",
+            value: "foo",
+        }));
+
+        let node = Node.fromArray(array);
+
+        test.ok(node);
+
+        test.equal(node.type, "root");
+        test.ok(node.children);
+        test.equal(node.children.length, 3);
+
+        test.ok(node.children[0]);
+        test.equal(node.children[0].type, "text");
+        test.equal(node.children[0].value, "asdf");
+
+        test.ok(node.children[1]);
+        test.equal(node.children[1].type, "parent");
+
+        test.ok(node.children[2]);
+        test.equal(node.children[2].type, "text");
+        test.equal(node.children[2].value, "foo");
+
+        test.done();
+    }
 };


### PR DESCRIPTION
If you had too many "end" nodes for the number of "start" nodes, then the fromArray code would throw an exception when it popped the last node off the stack and then tries to add the next node to "undefined". The solution is to not pop the root node off the bottom of the stack, so that all subsequent nodes get added to the root, regardless of the well-formedness of the array.