### PR TITLE
Reversion the last release as v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ let treeNode = map(ast, node => new Node(node));
 
 # Release Notes
 
-## v1.3.1
+## v2.0.0
 
 - convert all unit tests from nodeunit to jest
-- export the es6 code as real es6 modules
+- export the es6 code as real es6 modules and old transpiled javascript
+  for older packages to use (breaking change)
 
 ## v1.3.0
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ let ast = X; // some unist tree, probably from a parser
 let treeNode = map(ast, node => new Node(node));
 ```
 
+## License
+
+Copyright © 2018-2024, JEDLSoft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+
 # Release Notes
 
 ## v2.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-tree-node",
-    "version": "1.3.1",
+    "version": "2.0.0",
     "main": "./lib/TreeNode.js",
     "module": "./src/TreeNode.js",
     "exports": {


### PR DESCRIPTION
- the previous release (v1.3.1) had a breaking change, so reversioning it to v2.0.0 so that it doesn't break other things that depend on this when they use carat dependencies
- v1.3.1 is already deprecated in npm and we will publish v1.3.2 (= v1.3.0) to supercede it in the v1.x line